### PR TITLE
Prepare pyproject.toml for PyPI publishing

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,7 +5,7 @@ build-backend = "setuptools.build_meta"
 [project]
 name = "afterthoughts"
 version = "0.1.0"
-description = "Generate fine-grained contextualized phrase embeddings with transformers."
+description = "Sentence-aware embeddings using late chunking with transformers."
 readme = "README.md"
 authors = [
   {name = "Nicholas Gigliotti", email = "ndgigliotti@gmail.com"}


### PR DESCRIPTION
- Add requires-python >= 3.10
- Add PyPI classifiers for discoverability
- Update license to SPDX format (Apache-2.0)
- Fix project URLs from finephrase to afterthoughts